### PR TITLE
Added capturing group to prevent IndexOutOfBounds

### DIFF
--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -119,7 +119,7 @@ public class MicrosoftAuthenticator
         try {
             return loginWithTokens(extractTokens(result.getURL().toString()));
         } catch (MicrosoftAuthenticationException e) {
-            if (match("identity/confirm", http.readResponse(result)) != null) {
+            if (match("(identity/confirm)", http.readResponse(result)) != null) {
                 throw new MicrosoftAuthenticationException(
                         "User has enabled double-authentication or must allow sign-in on https://account.live.com/activity"
                 );


### PR DESCRIPTION
`Exception in thread "main" java.lang.IndexOutOfBoundsException: No group 1 at java.util.regex.Matcher.group(Unknown Source) at fr.litarvan.openauth.microsoft.MicrosoftAuthenticator.match(MicrosoftAuthenticator.java:305) at fr.litarvan.openauth.microsoft.MicrosoftAuthenticator.loginWithCredentials(MicrosoftAuthenticator.java:119) at `

The String "identity/confirm" doesn't contain a capturing group, thus the match function will throw an exception when trying to return the first matched capturing group.