### PR TITLE
Fix the need to type the password two times for it to work

### DIFF
--- a/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
@@ -69,10 +69,6 @@ public class LoginFrame extends JFrame
 
     protected void init(String url)
     {
-        java.net.CookieManager manager = new java.net.CookieManager();
-        java.net.CookieHandler.setDefault(manager);
-        manager.getCookieStore().removeAll();
-
         WebView webView = new WebView();
         JFXPanel content = (JFXPanel) this.getContentPane();
 

--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
  * @version 1.1.0
  */
 public class MicrosoftAuthenticator {
-    public static final String MICROSOFT_AUTHORIZATION_ENDPOINT = "https://login.live.com/oauth20_authorize.srf";
+    public static final String MICROSOFT_AUTHORIZATION_ENDPOINT = "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize";
     public static final String MICROSOFT_TOKEN_ENDPOINT = "https://login.live.com/oauth20_token.srf";
     public static final String MICROSOFT_REDIRECTION_ENDPOINT = "https://login.live.com/oauth20_desktop.srf";
 


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the contributing guidelines

### Changes

- [x] Internal code
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->


## Description

This PR fixes the need to type the password two times for it to work by reverting 354715ccb0b4924de893c5c8cab3ef2dc437ed20
Thanks Straixes#2770 for his time :).

NOTE :
The URL change is "optional" for this fix, but it matches better the Microsoft Auth API according to the Azure documentation (and for better relibaility if the API changes one day).

Video :

https://user-images.githubusercontent.com/52298108/208253344-c49c2a7c-1145-42c5-b0ee-b718908cb3ae.mp4
