### PR TITLE
Add to the MicrosoftAuthResult object the xuid and clientId arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'fr.litarvan'
-version = '1.1.4'
+version = '1.1.5'
 archivesBaseName = 'openauth'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
 }
 
 jar {
@@ -26,12 +26,12 @@ jar {
 }
 
 task javadocJar(type: Jar) {
-    classifier = 'javadoc'
+    classifier 'javadoc'
     from javadoc
 }
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    classifier 'sources'
     from sourceSets.main.allSource
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthResult.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthResult.java
@@ -29,19 +29,23 @@ import fr.litarvan.openauth.microsoft.model.response.MinecraftProfile;
  * </p>
  *
  * @author Litarvan
- * @version 1.1.0
+ * @version 1.1.5
  */
 public class MicrosoftAuthResult
 {
     private final MinecraftProfile profile;
     private final String accessToken;
     private final String refreshToken;
+    private final String xuid;
+    private final String clientId;
 
-    public MicrosoftAuthResult(MinecraftProfile profile, String accessToken, String refreshToken)
+    public MicrosoftAuthResult(MinecraftProfile profile, String accessToken, String refreshToken, String xuid, String clientId)
     {
         this.profile = profile;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.xuid = xuid;
+        this.clientId = clientId;
     }
 
     /**
@@ -67,5 +71,21 @@ public class MicrosoftAuthResult
     public String getRefreshToken()
     {
         return refreshToken;
+    }
+
+    /**
+     * @return The XUID of the player
+     */
+    public String getXuid()
+    {
+        return this.xuid;
+    }
+
+    /**
+     * @return The client ID of the player
+     */
+    public String getClientId()
+    {
+        return this.clientId;
     }
 }

--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -34,6 +34,7 @@ import fr.litarvan.openauth.microsoft.model.response.*;
 import java.io.UnsupportedEncodingException;
 import java.net.*;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -223,7 +224,13 @@ public class MicrosoftAuthenticator {
             );
         }
 
-        return new MicrosoftAuthResult(profile, minecraftResponse.getAccessToken(), tokens.getRefreshToken());
+        return new MicrosoftAuthResult(
+                profile,
+                minecraftResponse.getAccessToken(),
+                tokens.getRefreshToken(),
+                xboxLiveResponse.getDisplayClaims().getUsers()[0].getUserHash(),
+                Base64.getEncoder().encodeToString(minecraftResponse.getUsername().getBytes())
+        );
     }
 
 


### PR DESCRIPTION
## Important PR: Add to the MicrosoftAuthResult object the xuid and clientId arguments

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code & API

## Description
These strings are used for the new auth system implemented in 1.19 with the new multiplayer moderation feature

At some point, some clients that didn't add these args just can't connect to servers

ALSO: updated gradle and gson